### PR TITLE
grammar fix

### DIFF
--- a/src/languages/English.php
+++ b/src/languages/English.php
@@ -15,7 +15,7 @@ final class English extends Speller
 			1 => 'ten',
 			2 => 'twenty',
 			3 => 'thirty',
-			4 => 'fourty',
+			4 => 'forty',
 			5 => 'fifty',
 			6 => 'sixty',
 			7 => 'seventy',


### PR DESCRIPTION
There is no english word `fourty`

http://grammarist.com/spelling/forty-fourty/