### PR TITLE
Fixing variable naming bug

### DIFF
--- a/src/Speller.php
+++ b/src/Speller.php
@@ -241,7 +241,7 @@ abstract class Speller
 	
 	private static function assertNumber($number)
 	{
-		if (!is_numeric($amount))
+		if (!is_numeric($number))
 		{
 			throw new InvalidArgumentException('Invalid number specified.');
 		}


### PR DESCRIPTION
Function parameter variable name did not match the one used in it.