### PR TITLE
Splitting `getCurrencyName()` into two, thus getting rid of a flag parameter (`$type`).

### DIFF
--- a/src/Speller.php
+++ b/src/Speller.php
@@ -1,6 +1,7 @@
 <?php
 namespace js\tools\numbers2words;
 
+use Exception;
 use js\tools\numbers2words\exceptions\InvalidArgumentException;
 
 /**
@@ -152,7 +153,7 @@ abstract class Speller
 		
 		$text = trim($speller->parseInt($wholeAmount, false, $currency))
 			. ' '
-			. $speller->getCurrencyName('whole', $wholeAmount, $currency);
+			. $speller->getCurrencyNameMajor($wholeAmount, $currency);
 		
 		if ($requireDecimal || ($decimalAmount > 0))
 		{
@@ -161,7 +162,7 @@ abstract class Speller
 					? trim($speller->parseInt($decimalAmount, true, $currency))
 					: $decimalAmount)
 				. ' '
-				. $speller->getCurrencyName('decimal', $decimalAmount, $currency);
+				. $speller->getCurrencyNameMinor($decimalAmount, $currency);
 		}
 		
 		return $text;
@@ -229,7 +230,17 @@ abstract class Speller
 	
 	protected abstract function spellExponent(string $type, int $number, string $currency): string;
 	
-	protected abstract function getCurrencyName(string $type, int $number, string $currency): string;
+	protected abstract function getCurrencyNameMajor(int $amount, string $currency): string;
+	
+	protected abstract function getCurrencyNameMinor(int $amount, string $currency): string;
+	
+	/**
+	 * @deprecated Unnecessary in PHP8: https://wiki.php.net/rfc/throw_expression
+	 */
+	protected static function throw(Exception $exception): void
+	{
+		throw $exception;
+	}
 	
 	private static function assertNumber($number): void
 	{

--- a/src/languages/English.php
+++ b/src/languages/English.php
@@ -97,46 +97,40 @@ final class English extends Speller
 		return '';
 	}
 	
-	protected function getCurrencyName(string $type, int $number, string $currency): string
+	protected function getCurrencyNameMajor(int $amount, string $currency): string
 	{
 		static $names = [
-			self::CURRENCY_EURO           => [
-				'whole'   => ['euro', 'euro'],
-				'decimal' => ['cent', 'cents'],
-			],
-			self::CURRENCY_BRITISH_POUND  => [
-				'whole'   => ['pound', 'pounds'],
-				'decimal' => ['penny', 'pennies'],
-			],
-			self::CURRENCY_LATVIAN_LAT    => [
-				'whole'   => ['lat', 'lats'],
-				'decimal' => ['santim', 'santims'],
-			],
-			self::CURRENCY_LITHUANIAN_LIT => [
-				'whole'   => ['litas', 'litai'],
-				'decimal' => ['centas', 'centai'],
-			],
-			self::CURRENCY_RUSSIAN_ROUBLE => [
-				'whole'   => ['ruble', 'rubles'],
-				'decimal' => ['kopek', 'kopeks'],
-			],
-			self::CURRENCY_US_DOLLAR      => [
-				'whole'   => ['dollar', 'dollars'],
-				'decimal' => ['cent', 'cents'],
-			],
-			self::CURRENCY_PL_ZLOTY       => [
-				'whole'   => ['zloty', 'zlote'],
-				'decimal' => ['grosz', 'grosze'],
-			],
+			self::CURRENCY_EURO           => ['euro', 'euro'],
+			self::CURRENCY_BRITISH_POUND  => ['pound', 'pounds'],
+			self::CURRENCY_LATVIAN_LAT    => ['lat', 'lats'],
+			self::CURRENCY_LITHUANIAN_LIT => ['litas', 'litai'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['ruble', 'rubles'],
+			self::CURRENCY_US_DOLLAR      => ['dollar', 'dollars'],
+			self::CURRENCY_PL_ZLOTY       => ['zloty', 'zlote'],
 		];
 		
-		if (!isset($names[$currency]))
-		{
-			throw new InvalidArgumentException('Unsupported currency');
-		}
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	protected function getCurrencyNameMinor(int $amount, string $currency): string
+	{
+		static $names = [
+			self::CURRENCY_EURO           => ['cent', 'cents'],
+			self::CURRENCY_BRITISH_POUND  => ['penny', 'pennies'],
+			self::CURRENCY_LATVIAN_LAT    => ['santim', 'santims'],
+			self::CURRENCY_LITHUANIAN_LIT => ['centas', 'centai'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['kopek', 'kopeks'],
+			self::CURRENCY_US_DOLLAR      => ['cent', 'cents'],
+			self::CURRENCY_PL_ZLOTY       => ['grosz', 'grosze'],
+		];
 		
-		$index = (($number === 1) ? 0 : 1);
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	private static function getCurrencyName(array $names, int $amount, string $currency): string
+	{
+		$index = (($amount === 1) ? 0 : 1);
 		
-		return $names[$currency][$type][$index];
+		return $names[$currency][$index] ?? self::throw(new InvalidArgumentException('Unsupported currency'));
 	}
 }

--- a/src/languages/Estonian.php
+++ b/src/languages/Estonian.php
@@ -102,46 +102,40 @@ final class Estonian extends Speller
 		return '';
 	}
 	
-	protected function getCurrencyName(string $type, int $number, string $currency): string
+	protected function getCurrencyNameMajor(int $amount, string $currency): string
 	{
 		static $names = [
-			self::CURRENCY_EURO           => [
-				'whole'   => ['euro', 'eurot'],
-				'decimal' => ['sent', 'senti'],
-			],
-			self::CURRENCY_BRITISH_POUND  => [
-				'whole'   => ['nael', 'naela'],
-				'decimal' => ['penn', 'penni'],
-			],
-			self::CURRENCY_LATVIAN_LAT    => [
-				'whole'   => ['latt', 'latti'],
-				'decimal' => ['santiim', 'santiimi'],
-			],
-			self::CURRENCY_LITHUANIAN_LIT => [
-				'whole'   => ['litt', 'litti'],
-				'decimal' => ['sent', 'senti'],
-			],
-			self::CURRENCY_RUSSIAN_ROUBLE => [
-				'whole'   => ['rubla', 'rubla'],
-				'decimal' => ['kopikas', 'kopikat'],
-			],
-			self::CURRENCY_US_DOLLAR      => [
-				'whole'   => ['dollar', 'dollarit'],
-				'decimal' => ['sent', 'senti'],
-			],
-			self::CURRENCY_PL_ZLOTY       => [
-				'whole'   => ['zloty', 'zlote'],
-				'decimal' => ['grosz', 'grosze'],
-			],
+			self::CURRENCY_EURO           => ['euro', 'eurot'],
+			self::CURRENCY_BRITISH_POUND  => ['nael', 'naela'],
+			self::CURRENCY_LATVIAN_LAT    => ['latt', 'latti'],
+			self::CURRENCY_LITHUANIAN_LIT => ['litt', 'litti'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['rubla', 'rubla'],
+			self::CURRENCY_US_DOLLAR      => ['dollar', 'dollarit'],
+			self::CURRENCY_PL_ZLOTY       => ['zloty', 'zlote'],
 		];
 		
-		if (!isset($names[$currency]))
-		{
-			throw new InvalidArgumentException('Unsupported currency');
-		}
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	protected function getCurrencyNameMinor(int $amount, string $currency): string
+	{
+		static $names = [
+			self::CURRENCY_EURO           => ['sent', 'senti'],
+			self::CURRENCY_BRITISH_POUND  => ['penn', 'penni'],
+			self::CURRENCY_LATVIAN_LAT    => ['santiim', 'santiimi'],
+			self::CURRENCY_LITHUANIAN_LIT => ['sent', 'senti'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['kopikas', 'kopikat'],
+			self::CURRENCY_US_DOLLAR      => ['sent', 'senti'],
+			self::CURRENCY_PL_ZLOTY       => ['grosz', 'grosze'],
+		];
 		
-		$index = (($number === 1) ? 0 : 1);
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	private static function getCurrencyName(array $names, int $amount, string $currency): string
+	{
+		$index = (($amount === 1) ? 0 : 1);
 		
-		return $names[$currency][$type][$index];
+		return $names[$currency][$index] ?? self::throw(new InvalidArgumentException('Unsupported currency'));
 	}
 }

--- a/src/languages/Latvian.php
+++ b/src/languages/Latvian.php
@@ -145,46 +145,40 @@ final class Latvian extends Speller
 		return '';
 	}
 	
-	protected function getCurrencyName(string $type, int $number, string $currency): string
+	protected function getCurrencyNameMajor(int $amount, string $currency): string
 	{
 		static $names = [
-			self::CURRENCY_EURO           => [
-				'whole'   => ['eiro', 'eiro', 'eiro'],
-				'decimal' => ['cents', 'centi', 'centu'],
-			],
-			self::CURRENCY_BRITISH_POUND  => [
-				'whole'   => ['mārciņa', 'mārciņas', 'mārciņu'],
-				'decimal' => ['penijs', 'peniji', 'peniju'],
-			],
-			self::CURRENCY_LATVIAN_LAT    => [
-				'whole'   => ['lats', 'lati', 'latu'],
-				'decimal' => ['santīms', 'santīmi', 'santīmu'],
-			],
-			self::CURRENCY_LITHUANIAN_LIT => [
-				'whole'   => ['lits', 'liti', 'litu'],
-				'decimal' => ['cents', 'centi', 'centu'],
-			],
-			self::CURRENCY_RUSSIAN_ROUBLE => [
-				'whole'   => ['rublis', 'rubļi', 'rubļu'],
-				'decimal' => ['kapeika', 'kapeikas', 'kapeiku'],
-			],
-			self::CURRENCY_US_DOLLAR      => [
-				'whole'   => ['dolārs', 'dolāri', 'dolāru'],
-				'decimal' => ['cents', 'centi', 'centu'],
-			],
-			self::CURRENCY_PL_ZLOTY       => [
-				'whole'   => ['zlots', 'zloti', 'zlotu'],
-				'decimal' => ['grosis', 'groši', 'grošu'],
-			],
+			self::CURRENCY_EURO           => ['eiro', 'eiro', 'eiro'],
+			self::CURRENCY_BRITISH_POUND  => ['mārciņa', 'mārciņas', 'mārciņu'],
+			self::CURRENCY_LATVIAN_LAT    => ['lats', 'lati', 'latu'],
+			self::CURRENCY_LITHUANIAN_LIT => ['lits', 'liti', 'litu'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['rublis', 'rubļi', 'rubļu'],
+			self::CURRENCY_US_DOLLAR      => ['dolārs', 'dolāri', 'dolāru'],
+			self::CURRENCY_PL_ZLOTY       => ['zlots', 'zloti', 'zlotu'],
 		];
 		
-		if (!isset($names[$currency]))
-		{
-			throw new InvalidArgumentException('Unsupported currency');
-		}
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	protected function getCurrencyNameMinor(int $amount, string $currency): string
+	{
+		static $names = [
+			self::CURRENCY_EURO           => ['cents', 'centi', 'centu'],
+			self::CURRENCY_BRITISH_POUND  => ['penijs', 'peniji', 'peniju'],
+			self::CURRENCY_LATVIAN_LAT    => ['santīms', 'santīmi', 'santīmu'],
+			self::CURRENCY_LITHUANIAN_LIT => ['cents', 'centi', 'centu'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['kapeika', 'kapeikas', 'kapeiku'],
+			self::CURRENCY_US_DOLLAR      => ['cents', 'centi', 'centu'],
+			self::CURRENCY_PL_ZLOTY       => ['grosis', 'groši', 'grošu'],
+		];
 		
-		$tens = $number % 100;
-		$singles = $number % 10;
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	private static function getCurrencyName(array $names, int $amount, string $currency): string
+	{
+		$tens = $amount % 100;
+		$singles = $amount % 10;
 		
 		if (($singles === 1) && ($tens !== 11)) // 1, 21, 31, ... 91
 		{
@@ -200,6 +194,6 @@ final class Latvian extends Speller
 			$index = 2;
 		}
 		
-		return $names[$currency][$type][$index];
+		return $names[$currency][$index] ?? self::throw(new InvalidArgumentException('Unsupported currency'));
 	}
 }

--- a/src/languages/Lithuanian.php
+++ b/src/languages/Lithuanian.php
@@ -121,46 +121,40 @@ final class Lithuanian extends Speller
 		return '';
 	}
 	
-	protected function getCurrencyName(string $type, int $number, string $currency): string
+	protected function getCurrencyNameMajor(int $amount, string $currency): string
 	{
 		static $names = [
-			self::CURRENCY_EURO           => [
-				'whole'   => ['euras', 'eurai', 'eurų'],
-				'decimal' => ['centas', 'centai', 'centų'],
-			],
-			self::CURRENCY_BRITISH_POUND  => [
-				'whole'   => ['svaras', 'svarai', 'svarų'],
-				'decimal' => ['pensas', 'pensai', 'pensų'],
-			],
-			self::CURRENCY_LATVIAN_LAT    => [
-				'whole'   => ['latas', 'latai', 'latų'],
-				'decimal' => ['santimas', 'santimai', 'santimų'],
-			],
-			self::CURRENCY_LITHUANIAN_LIT => [
-				'whole'   => ['litas', 'litai', 'litų'],
-				'decimal' => ['centas', 'centai', 'centų'],
-			],
-			self::CURRENCY_RUSSIAN_ROUBLE => [
-				'whole'   => ['rublis', 'rubliai', 'rublių'],
-				'decimal' => ['kapeika', 'kapeikos', 'kapeikų'],
-			],
-			self::CURRENCY_US_DOLLAR      => [
-				'whole'   => ['doleris', 'doleriai', 'dolerių'],
-				'decimal' => ['centas', 'centai', 'centų'],
-			],
-			self::CURRENCY_PL_ZLOTY       => [
-				'whole'   => ['zlotas', 'zlotai', 'zlotų'],
-				'decimal' => ['grašis', 'grašiai', 'grašių'],
-			],
+			self::CURRENCY_EURO           => ['euras', 'eurai', 'eurų'],
+			self::CURRENCY_BRITISH_POUND  => ['svaras', 'svarai', 'svarų'],
+			self::CURRENCY_LATVIAN_LAT    => ['latas', 'latai', 'latų'],
+			self::CURRENCY_LITHUANIAN_LIT => ['litas', 'litai', 'litų'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['rublis', 'rubliai', 'rublių'],
+			self::CURRENCY_US_DOLLAR      => ['doleris', 'doleriai', 'dolerių'],
+			self::CURRENCY_PL_ZLOTY       => ['zlotas', 'zlotai', 'zlotų'],
 		];
 		
-		if (!isset($names[$currency]))
-		{
-			throw new InvalidArgumentException('Unsupported currency');
-		}
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	protected function getCurrencyNameMinor(int $amount, string $currency): string
+	{
+		static $names = [
+			self::CURRENCY_EURO           => ['centas', 'centai', 'centų'],
+			self::CURRENCY_BRITISH_POUND  => ['pensas', 'pensai', 'pensų'],
+			self::CURRENCY_LATVIAN_LAT    => ['santimas', 'santimai', 'santimų'],
+			self::CURRENCY_LITHUANIAN_LIT => ['centas', 'centai', 'centų'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['kapeika', 'kapeikos', 'kapeikų'],
+			self::CURRENCY_US_DOLLAR      => ['centas', 'centai', 'centų'],
+			self::CURRENCY_PL_ZLOTY       => ['grašis', 'grašiai', 'grašių'],
+		];
 		
-		$tens = $number % 100;
-		$singles = $number % 10;
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	private static function getCurrencyName(array $names, int $amount, string $currency): string
+	{
+		$tens = $amount % 100;
+		$singles = $amount % 10;
 		
 		if (($singles === 1) && ($tens !== 11)) // 1, 21, 31, ... 91
 		{
@@ -176,6 +170,6 @@ final class Lithuanian extends Speller
 			$index = 2;
 		}
 		
-		return $names[$currency][$type][$index];
+		return $names[$currency][$index] ?? self::throw(new InvalidArgumentException('Unsupported currency'));
 	}
 }

--- a/src/languages/Polish.php
+++ b/src/languages/Polish.php
@@ -156,46 +156,40 @@ final class Polish extends Speller
 		return '';
 	}
 	
-	protected function getCurrencyName(string $type, int $number, string $currency): string
+	protected function getCurrencyNameMajor(int $amount, string $currency): string
 	{
 		static $names = [
-			self::CURRENCY_EURO           => [
-				'whole'   => ['euro', 'euro', 'euro'],
-				'decimal' => ['cent', 'centy', 'centów'],
-			],
-			self::CURRENCY_BRITISH_POUND  => [
-				'whole'   => ['funt', 'funty', 'funtów'],
-				'decimal' => ['pen', 'peny', 'penów'],
-			],
-			self::CURRENCY_LATVIAN_LAT    => [
-				'whole'   => ['łat', 'łaty', 'łatów'],
-				'decimal' => ['santim', 'santimy', 'santimów'],
-			],
-			self::CURRENCY_LITHUANIAN_LIT => [
-				'whole'   => ['lit', 'lity', 'litów'],
-				'decimal' => ['cent', 'centy', 'centów'],
-			],
-			self::CURRENCY_RUSSIAN_ROUBLE => [
-				'whole'   => ['rubel', 'ruble', 'rubli'],
-				'decimal' => ['kopiejka', 'kopiejki', 'kopiejek'],
-			],
-			self::CURRENCY_US_DOLLAR      => [
-				'whole'   => ['dolar', 'dolary', 'dolarów'],
-				'decimal' => ['cent', 'centy', 'centów'],
-			],
-			self::CURRENCY_PL_ZLOTY       => [
-				'whole'   => ['złoty', 'złote', 'złotych'],
-				'decimal' => ['grosz', 'grosze', 'groszy'],
-			],
+			self::CURRENCY_EURO           => ['euro', 'euro', 'euro'],
+			self::CURRENCY_BRITISH_POUND  => ['funt', 'funty', 'funtów'],
+			self::CURRENCY_LATVIAN_LAT    => ['łat', 'łaty', 'łatów'],
+			self::CURRENCY_LITHUANIAN_LIT => ['lit', 'lity', 'litów'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['rubel', 'ruble', 'rubli'],
+			self::CURRENCY_US_DOLLAR      => ['dolar', 'dolary', 'dolarów'],
+			self::CURRENCY_PL_ZLOTY       => ['złoty', 'złote', 'złotych'],
 		];
 		
-		if (!isset($names[$currency]))
-		{
-			throw new InvalidArgumentException('Unsupported currency');
-		}
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	protected function getCurrencyNameMinor(int $amount, string $currency): string
+	{
+		static $names = [
+			self::CURRENCY_EURO           => ['cent', 'centy', 'centów'],
+			self::CURRENCY_BRITISH_POUND  => ['pen', 'peny', 'penów'],
+			self::CURRENCY_LATVIAN_LAT    => ['santim', 'santimy', 'santimów'],
+			self::CURRENCY_LITHUANIAN_LIT => ['cent', 'centy', 'centów'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['kopiejka', 'kopiejki', 'kopiejek'],
+			self::CURRENCY_US_DOLLAR      => ['cent', 'centy', 'centów'],
+			self::CURRENCY_PL_ZLOTY       => ['grosz', 'grosze', 'groszy'],
+		];
 		
-		$tens = $number % 100;
-		$singles = $number % 10;
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	private static function getCurrencyName(array $names, int $amount, string $currency): string
+	{
+		$tens = $amount % 100;
+		$singles = $amount % 10;
 		
 		if (($singles === 1) && ($tens !== 11)) // 1, 21, ... 91
 		{
@@ -211,6 +205,6 @@ final class Polish extends Speller
 			$index = 2;
 		}
 		
-		return $names[$currency][$type][$index];
+		return $names[$currency][$index] ?? self::throw(new InvalidArgumentException('Unsupported currency'));
 	}
 }

--- a/src/languages/Russian.php
+++ b/src/languages/Russian.php
@@ -157,46 +157,40 @@ final class Russian extends Speller
 		return '';
 	}
 	
-	protected function getCurrencyName(string $type, int $number, string $currency): string
+	protected function getCurrencyNameMajor(int $amount, string $currency): string
 	{
 		static $names = [
-			self::CURRENCY_EURO           => [
-				'whole'   => ['евро', 'евро', 'евро'],
-				'decimal' => ['цент', 'цента', 'центов'],
-			],
-			self::CURRENCY_BRITISH_POUND  => [
-				'whole'   => ['фунт', 'фунта', 'фунтов'],
-				'decimal' => ['пенни', 'пенса', 'пенсов'],
-			],
-			self::CURRENCY_LATVIAN_LAT    => [
-				'whole'   => ['лат', 'лата', 'латов'],
-				'decimal' => ['сантим', 'сантима', 'сантимов'],
-			],
-			self::CURRENCY_LITHUANIAN_LIT => [
-				'whole'   => ['лит', 'лита', 'литов'],
-				'decimal' => ['цент', 'цента', 'центов'],
-			],
-			self::CURRENCY_RUSSIAN_ROUBLE => [
-				'whole'   => ['рубль', 'рубля', 'рублей'],
-				'decimal' => ['копейка', 'копейки', 'копеек'],
-			],
-			self::CURRENCY_US_DOLLAR      => [
-				'whole'   => ['доллар', 'доллара', 'долларов'],
-				'decimal' => ['цент', 'цента', 'центов'],
-			],
-			self::CURRENCY_PL_ZLOTY       => [
-				'whole'   => ['зло́тый', 'злота', 'злотых'],
-				'decimal' => ['грош', 'гроша', 'грошей'],
-			],
+			self::CURRENCY_EURO           => ['евро', 'евро', 'евро'],
+			self::CURRENCY_BRITISH_POUND  => ['фунт', 'фунта', 'фунтов'],
+			self::CURRENCY_LATVIAN_LAT    => ['лат', 'лата', 'латов'],
+			self::CURRENCY_LITHUANIAN_LIT => ['лит', 'лита', 'литов'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['рубль', 'рубля', 'рублей'],
+			self::CURRENCY_US_DOLLAR      => ['доллар', 'доллара', 'долларов'],
+			self::CURRENCY_PL_ZLOTY       => ['зло́тый', 'злота', 'злотых'],
 		];
 		
-		if (!isset($names[$currency]))
-		{
-			throw new InvalidArgumentException('Unsupported currency');
-		}
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	protected function getCurrencyNameMinor(int $amount, string $currency): string
+	{
+		static $names = [
+			self::CURRENCY_EURO           => ['цент', 'цента', 'центов'],
+			self::CURRENCY_BRITISH_POUND  => ['пенни', 'пенса', 'пенсов'],
+			self::CURRENCY_LATVIAN_LAT    => ['сантим', 'сантима', 'сантимов'],
+			self::CURRENCY_LITHUANIAN_LIT => ['цент', 'цента', 'центов'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['копейка', 'копейки', 'копеек'],
+			self::CURRENCY_US_DOLLAR      => ['цент', 'цента', 'центов'],
+			self::CURRENCY_PL_ZLOTY       => ['грош', 'гроша', 'грошей'],
+		];
 		
-		$tens = $number % 100;
-		$singles = $number % 10;
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	private static function getCurrencyName(array $names, int $amount, string $currency): string
+	{
+		$tens = $amount % 100;
+		$singles = $amount % 10;
 		
 		if (($singles === 1) && ($tens !== 11)) // 1, 21, ... 91
 		{
@@ -212,6 +206,6 @@ final class Russian extends Speller
 			$index = 2;
 		}
 		
-		return $names[$currency][$type][$index];
+		return $names[$currency][$index] ?? self::throw(new InvalidArgumentException('Unsupported currency'));
 	}
 }

--- a/src/languages/Spanish.php
+++ b/src/languages/Spanish.php
@@ -128,57 +128,44 @@ final class Spanish extends Speller
 		return '';
 	}
 	
-	protected function getCurrencyName(string $type, int $number, string $currency): string
+	protected function getCurrencyNameMajor(int $amount, string $currency): string
 	{
 		// TODO some of these spellings are extremely hard to find and are probably incorrect
 		static $names = [
-			self::CURRENCY_EURO           => [
-				'whole'   => ['euro', 'euros'],
-				'decimal' => ['centime', 'centimes'],
-			],
-			self::CURRENCY_BRITISH_POUND  => [
-				'whole'   => ['libra esterlina', 'libras esterlinas'],
-				'decimal' => ['penique', 'peniques'],
-			],
-			self::CURRENCY_LATVIAN_LAT    => [
-				'whole'   => ['lat', 'lats'],
-				'decimal' => ['sentim', 'sentims'],
-			],
-			self::CURRENCY_LITHUANIAN_LIT => [
-				'whole'   => ['litas', 'litas'],
-				'decimal' => ['cent', 'cents'],
-			],
-			self::CURRENCY_RUSSIAN_ROUBLE => [
-				'whole'   => ['rublo ruso', 'rublos rusos'],
-				'decimal' => ['kopek', 'kopeks'],
-			],
-			self::CURRENCY_US_DOLLAR      => [
-				'whole'   => ['dólar estadounidense', 'dólares estadounidenses'],
-				'decimal' => ['centavo', 'centavos'],
-			],
-			self::CURRENCY_PL_ZLOTY       => [
-				'whole'   => ['zloty', 'zlotys'],
-				'decimal' => ['centavo', 'centavos'],
-			],
+			self::CURRENCY_EURO           => ['euro', 'euros'],
+			self::CURRENCY_BRITISH_POUND  => ['libra esterlina', 'libras esterlinas'],
+			self::CURRENCY_LATVIAN_LAT    => ['lat', 'lats'],
+			self::CURRENCY_LITHUANIAN_LIT => ['litas', 'litas'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['rublo ruso', 'rublos rusos'],
+			self::CURRENCY_US_DOLLAR      => ['dólar estadounidense', 'dólares estadounidenses'],
+			self::CURRENCY_PL_ZLOTY       => ['zloty', 'zlotys'],
 		];
 		
-		if (!isset($names[$currency]))
-		{
-			throw new InvalidArgumentException('Unsupported currency');
-		}
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	protected function getCurrencyNameMinor(int $amount, string $currency): string
+	{
+		static $names = [
+			self::CURRENCY_EURO           => ['centime', 'centimes'],
+			self::CURRENCY_BRITISH_POUND  => ['penique', 'peniques'],
+			self::CURRENCY_LATVIAN_LAT    => ['sentim', 'sentims'],
+			self::CURRENCY_LITHUANIAN_LIT => ['cent', 'cents'],
+			self::CURRENCY_RUSSIAN_ROUBLE => ['kopek', 'kopeks'],
+			self::CURRENCY_US_DOLLAR      => ['centavo', 'centavos'],
+			self::CURRENCY_PL_ZLOTY       => ['grosz', 'grosze'],
+		];
 		
-		$tens = $number % 100;
-		$singles = $number % 10;
+		return self::getCurrencyName($names, $amount, $currency);
+	}
+	
+	private static function getCurrencyName(array $names, int $amount, string $currency): string
+	{
+		$tens = $amount % 100;
+		$singles = $amount % 10;
 		
-		if (($singles === 1) && ($tens !== 11)) // 1, 21, ... 91
-		{
-			$index = 0;
-		}
-		else
-		{
-			$index = 1;
-		}
+		$index = ((($singles === 1) && ($tens !== 11)) ? 0 : 1);
 		
-		return $names[$currency][$type][$index];
+		return $names[$currency][$index] ?? self::throw(new InvalidArgumentException('Unsupported currency'));
 	}
 }


### PR DESCRIPTION
Using a short `isset() or throw` syntax that's currently possible only via an intermediate function on the right side of `or` (in PHP8 it will work without the middleman).
It's not everyone's cup of tea, but I don't care.